### PR TITLE
Week2-2: State

### DIFF
--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
@@ -21,6 +21,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import com.codelabs.state.ui.StateCodelabTheme
 
 class TodoActivity : AppCompatActivity() {
@@ -32,9 +35,18 @@ class TodoActivity : AppCompatActivity() {
         setContent {
             StateCodelabTheme {
                 Surface {
-                    // TODO: build the screen in compose
+                    TodoActivityScreen(todoViewModel = todoViewModel)
                 }
             }
         }
+    }
+
+    @Composable
+    private fun TodoActivityScreen(todoViewModel: TodoViewModel) {
+        val items: List<TodoItem> by todoViewModel.todoItems.observeAsState(initial = listOf())
+        TodoScreen(
+            items = items, onAddItem = todoViewModel::addItem, onRemoveItem =
+            todoViewModel::removeItem
+        )
     }
 }

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
@@ -45,8 +45,12 @@ class TodoActivity : AppCompatActivity() {
     private fun TodoActivityScreen(todoViewModel: TodoViewModel) {
         TodoScreen(
             items = todoViewModel.todoItems,
+            currentlyEditing = todoViewModel.currentEditItem,
             onAddItem = todoViewModel::addItem,
-            onRemoveItem = todoViewModel::removeItem
+            onRemoveItem = todoViewModel::removeItem,
+            onStartEdit = todoViewModel::onEditItemSelected,
+            onEditItemChange = todoViewModel::onEditItemSelected,
+            onEditDone = todoViewModel::onEditDone
         )
     }
 }

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
@@ -43,10 +43,10 @@ class TodoActivity : AppCompatActivity() {
 
     @Composable
     private fun TodoActivityScreen(todoViewModel: TodoViewModel) {
-        val items: List<TodoItem> by todoViewModel.todoItems.observeAsState(initial = listOf())
         TodoScreen(
-            items = items, onAddItem = todoViewModel::addItem, onRemoveItem =
-            todoViewModel::removeItem
+            items = todoViewModel.todoItems,
+            onAddItem = todoViewModel::addItem,
+            onRemoveItem = todoViewModel::removeItem
         )
     }
 }

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoActivity.kt
@@ -49,7 +49,7 @@ class TodoActivity : AppCompatActivity() {
             onAddItem = todoViewModel::addItem,
             onRemoveItem = todoViewModel::removeItem,
             onStartEdit = todoViewModel::onEditItemSelected,
-            onEditItemChange = todoViewModel::onEditItemSelected,
+            onEditItemChange = todoViewModel::onEditItemChange,
             onEditDone = todoViewModel::onEditDone
         )
     }

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -84,7 +85,12 @@ fun TodoScreen(
  * @param modifier modifier for this element
  */
 @Composable
-fun TodoRow(todo: TodoItem, onItemClicked: (TodoItem) -> Unit, modifier: Modifier = Modifier) {
+fun TodoRow(
+    todo: TodoItem,
+    onItemClicked: (TodoItem) -> Unit,
+    modifier: Modifier = Modifier,
+    iconAlpha: Float = remember(todo.id) { randomTint() }
+) {
     Row(
         modifier = modifier
             .clickable { onItemClicked(todo) }
@@ -94,6 +100,7 @@ fun TodoRow(todo: TodoItem, onItemClicked: (TodoItem) -> Unit, modifier: Modifie
         Text(todo.task)
         Icon(
             imageVector = todo.icon.imageVector,
+            tint = LocalContentColor.current.copy(alpha = iconAlpha),
             contentDescription = stringResource(id = todo.icon.contentDescription)
         )
     }

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -17,24 +17,22 @@
 package com.codelabs.state.todo
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Button
-import androidx.compose.material.Icon
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.Text
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.codelabs.state.util.generateRandomTodoItem
@@ -119,6 +117,13 @@ private fun randomTint(): Float {
 @Composable
 fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
     val (text, setText) = remember { mutableStateOf("") }
+    val (icon, setIcon) = remember { mutableStateOf(TodoIcon.Default) }
+    val iconsVisible = text.isNotBlank()
+    val submit = {
+        onItemComplete(TodoItem(text, icon))
+        setIcon(TodoIcon.Default)
+        setText("")
+    }
     Column {
         Row(
             Modifier
@@ -130,24 +135,46 @@ fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
                 onTextChange = setText,
                 modifier = Modifier
                     .weight(1f)
-                    .padding(end = 8.dp)
+                    .padding(end = 8.dp),
+                onImeAction = submit
             )
             TodoEditButton(
-                onClick = {
-                    onItemComplete(TodoItem(text))
-                    setText("")
-                },
+                onClick = submit,
                 text = "Add",
                 modifier = Modifier.align(Alignment.CenterVertically),
                 enabled = text.isNotBlank()
             )
         }
+
+        if (iconsVisible) {
+            AnimatedIconRow(
+                icon = icon, onIconChange = setIcon, modifier = Modifier.padding(top = 8.dp)
+            )
+        } else {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun TodoInputTextField(text: String, onTextChange: (String) -> Unit, modifier: Modifier) {
-    TodoInputText(text = text, onTextChange = onTextChange, modifier = modifier)
+fun TodoInputTextField(
+    text: String, onTextChange: (String) -> Unit, modifier: Modifier,
+    onImeAction: () -> Unit = {}
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    TextField(
+        value = text,
+        onValueChange = onTextChange,
+        colors = TextFieldDefaults.textFieldColors(backgroundColor = Color.Transparent),
+        maxLines = 1,
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = {
+            onImeAction()
+            keyboardController?.hide()
+        }),
+        modifier = modifier
+    )
 }
 
 @Preview

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -52,6 +54,10 @@ fun TodoScreen(
     onRemoveItem: (TodoItem) -> Unit
 ) {
     Column {
+        TodoItemInputBackground(elevate = true, modifier = Modifier.fillMaxWidth()) {
+            TodoItemInput(onItemComplete = onAddItem)
+        }
+
         LazyColumn(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(top = 8.dp)
@@ -59,7 +65,7 @@ fun TodoScreen(
             items(items = items) {
                 TodoRow(
                     todo = it,
-                    onItemClicked = { onRemoveItem(it) },
+                    onItemClicked = { item -> onRemoveItem(item) },
                     modifier = Modifier.fillParentMaxWidth()
                 )
             }
@@ -110,6 +116,40 @@ private fun randomTint(): Float {
     return Random.nextFloat().coerceIn(0.3f, 0.9f)
 }
 
+@Composable
+fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
+    val (text, setText) = remember { mutableStateOf("") }
+    Column {
+        Row(
+            Modifier
+                .padding(horizontal = 16.dp)
+                .padding(top = 16.dp)
+        ) {
+            TodoInputTextField(
+                text = text,
+                onTextChange = setText,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 8.dp)
+            )
+            TodoEditButton(
+                onClick = {
+                    onItemComplete(TodoItem(text))
+                    setText("")
+                },
+                text = "Add",
+                modifier = Modifier.align(Alignment.CenterVertically),
+                enabled = text.isNotBlank()
+            )
+        }
+    }
+}
+
+@Composable
+fun TodoInputTextField(text: String, onTextChange: (String) -> Unit, modifier: Modifier) {
+    TodoInputText(text = text, onTextChange = onTextChange, modifier = modifier)
+}
+
 @Preview
 @Composable
 fun PreviewTodoScreen() {
@@ -128,3 +168,7 @@ fun PreviewTodoRow() {
     val todo = remember { generateRandomTodoItem() }
     TodoRow(todo = todo, onItemClicked = {}, modifier = Modifier.fillMaxWidth())
 }
+
+@Preview
+@Composable
+fun PreviewTodoItemInput() = TodoItemInput(onItemComplete = {})

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -53,7 +53,7 @@ fun TodoScreen(
 ) {
     Column {
         TodoItemInputBackground(elevate = true, modifier = Modifier.fillMaxWidth()) {
-            TodoItemInput(onItemComplete = onAddItem)
+            TodoItemEntryInput(onItemComplete = onAddItem)
         }
 
         LazyColumn(
@@ -115,7 +115,7 @@ private fun randomTint(): Float {
 }
 
 @Composable
-fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
+fun TodoItemEntryInput(onItemComplete: (TodoItem) -> Unit) {
     val (text, setText) = remember { mutableStateOf("") }
     val (icon, setIcon) = remember { mutableStateOf(TodoIcon.Default) }
     val iconsVisible = text.isNotBlank()
@@ -124,6 +124,25 @@ fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
         setIcon(TodoIcon.Default)
         setText("")
     }
+    TodoItemInput(
+        text = text,
+        onTextChange = setText,
+        icon = icon,
+        onIconChange = setIcon,
+        submit = submit,
+        iconsVisible = iconsVisible
+    )
+}
+
+@Composable
+fun TodoItemInput(
+    text: String,
+    onTextChange: (String) -> Unit,
+    icon: TodoIcon,
+    onIconChange: (TodoIcon) -> Unit,
+    submit: () -> Unit,
+    iconsVisible: Boolean
+) {
     Column {
         Row(
             Modifier
@@ -132,7 +151,7 @@ fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
         ) {
             TodoInputTextField(
                 text = text,
-                onTextChange = setText,
+                onTextChange = onTextChange,
                 modifier = Modifier
                     .weight(1f)
                     .padding(end = 8.dp),
@@ -148,7 +167,7 @@ fun TodoItemInput(onItemComplete: (TodoItem) -> Unit) {
 
         if (iconsVisible) {
             AnimatedIconRow(
-                icon = icon, onIconChange = setIcon, modifier = Modifier.padding(top = 8.dp)
+                icon = icon, onIconChange = onIconChange, modifier = Modifier.padding(top = 8.dp)
             )
         } else {
             Spacer(modifier = Modifier.height(16.dp))
@@ -198,4 +217,4 @@ fun PreviewTodoRow() {
 
 @Preview
 @Composable
-fun PreviewTodoItemInput() = TodoItemInput(onItemComplete = {})
+fun PreviewTodoItemEntryInput() = TodoItemEntryInput(onItemComplete = {})

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -158,7 +158,9 @@ fun TodoItemEntryInput(onItemComplete: (TodoItem) -> Unit) {
         onIconChange = setIcon,
         submit = submit,
         iconsVisible = iconsVisible
-    )
+    ) {
+        TodoEditButton(onClick = submit, text = "Add", enabled = text.isNotBlank())
+    }
 }
 
 @Composable
@@ -171,7 +173,26 @@ fun TodoItemInlineEditor(
     icon = item.icon,
     onIconChange = { onEditItemChange(item.copy(icon = it)) },
     submit = onEditDone,
-    iconsVisible = true
+    iconsVisible = true,
+    buttonSlot = {
+        Row {
+            val shrinkButtons = Modifier.widthIn(20.dp)
+            TextButton(onClick = onEditDone, modifier = shrinkButtons) {
+                Text(
+                    text = "\uD83D\uDCBE", // floppy disk
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.width(30.dp)
+                )
+            }
+            TextButton(onClick = onRemoveItem, modifier = shrinkButtons) {
+                Text(
+                    text = "❌",
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.width(30.dp)
+                )
+            }
+        }
+    }
 )
 
 @Composable
@@ -181,7 +202,8 @@ fun TodoItemInput(
     icon: TodoIcon,
     onIconChange: (TodoIcon) -> Unit,
     submit: () -> Unit,
-    iconsVisible: Boolean
+    iconsVisible: Boolean,
+    buttonSlot: @Composable () -> Unit
 ) {
     Column {
         Row(
@@ -197,12 +219,8 @@ fun TodoItemInput(
                     .padding(end = 8.dp),
                 onImeAction = submit
             )
-            TodoEditButton(
-                onClick = submit,
-                text = "Add",
-                modifier = Modifier.align(Alignment.CenterVertically),
-                enabled = text.isNotBlank()
-            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(Modifier.align(Alignment.CenterVertically)) { buttonSlot() }
         }
 
         if (iconsVisible) {

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.codelabs.state.util.generateRandomTodoItem
@@ -48,24 +49,50 @@ import kotlin.random.Random
 @Composable
 fun TodoScreen(
     items: List<TodoItem>,
+    currentlyEditing: TodoItem?,
     onAddItem: (TodoItem) -> Unit,
-    onRemoveItem: (TodoItem) -> Unit
+    onRemoveItem: (TodoItem) -> Unit,
+    onStartEdit: (TodoItem) -> Unit,
+    onEditItemChange: (TodoItem) -> Unit,
+    onEditDone: () -> Unit
 ) {
     Column {
-        TodoItemInputBackground(elevate = true, modifier = Modifier.fillMaxWidth()) {
-            TodoItemEntryInput(onItemComplete = onAddItem)
+        val enableTopSection = currentlyEditing == null
+        TodoItemInputBackground(elevate = enableTopSection) {
+            if (enableTopSection) {
+                TodoItemEntryInput(onAddItem)
+            } else {
+                Text(
+                    "Editing item",
+                    style = MaterialTheme.typography.h6,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .padding(16.dp)
+                        .fillMaxWidth()
+                )
+            }
         }
 
         LazyColumn(
             modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(top = 8.dp)
         ) {
-            items(items = items) {
-                TodoRow(
-                    todo = it,
-                    onItemClicked = { item -> onRemoveItem(item) },
-                    modifier = Modifier.fillParentMaxWidth()
-                )
+            items(items = items) { todo ->
+                if (currentlyEditing?.id == todo.id) {
+                    TodoItemInlineEditor(
+                        item = currentlyEditing,
+                        onEditItemChange = onEditItemChange,
+                        onEditDone = onEditDone,
+                        onRemoveItem = { onRemoveItem(todo) }
+                    )
+                } else {
+                    TodoRow(
+                        todo = todo,
+                        onItemClicked = onStartEdit,
+                        modifier = Modifier.fillParentMaxWidth()
+                    )
+                }
             }
         }
 
@@ -133,6 +160,19 @@ fun TodoItemEntryInput(onItemComplete: (TodoItem) -> Unit) {
         iconsVisible = iconsVisible
     )
 }
+
+@Composable
+fun TodoItemInlineEditor(
+    item: TodoItem, onEditItemChange: (TodoItem) -> Unit, onEditDone: () ->
+    Unit, onRemoveItem: () -> Unit
+) = TodoItemInput(
+    text = item.task,
+    onTextChange = { onEditItemChange(item.copy(task = it)) },
+    icon = item.icon,
+    onIconChange = { onEditItemChange(item.copy(icon = it)) },
+    submit = onEditDone,
+    iconsVisible = true
+)
 
 @Composable
 fun TodoItemInput(
@@ -205,7 +245,7 @@ fun PreviewTodoScreen() {
         TodoItem("Apply state", TodoIcon.Done),
         TodoItem("Build dynamic UIs", TodoIcon.Square)
     )
-    TodoScreen(items, {}, {})
+    TodoScreen(items, null, {}, {}, {}, {}, {})
 }
 
 @Preview

--- a/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoViewModel.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/main/java/com/codelabs/state/todo/TodoViewModel.kt
@@ -16,22 +16,45 @@
 
 package com.codelabs.state.todo
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 
 class TodoViewModel : ViewModel() {
 
-    private var _todoItems = MutableLiveData(listOf<TodoItem>())
-    val todoItems: LiveData<List<TodoItem>> = _todoItems
+    private var currentEditPosition by mutableStateOf(-1)
+
+    // extends MutableList, so use just like mutableList
+    var todoItems = mutableStateListOf<TodoItem>()
+        private set
+
+    val currentEditItem: TodoItem?
+        get() = todoItems.getOrNull(currentEditPosition)
 
     fun addItem(item: TodoItem) {
-        _todoItems.value = _todoItems.value!! + listOf(item)
+        todoItems.add(item)
     }
 
     fun removeItem(item: TodoItem) {
-        _todoItems.value = _todoItems.value!!.toMutableList().also {
-            it.remove(item)
+        todoItems.remove(item)
+        onEditDone()
+    }
+
+    fun onEditItemSelected(item: TodoItem) {
+        currentEditPosition = todoItems.indexOf(item)
+    }
+
+    fun onEditDone() {
+        currentEditPosition = 1
+    }
+
+    fun onEditItemChange(item: TodoItem) {
+        val currentItem = requireNotNull(currentEditItem)
+        require(currentItem.id == item.id) {
+            "You can only change an item with the same id as currentEditItem"
         }
+        todoItems[currentEditPosition] = item
     }
 }

--- a/week 2-2-Using state in Jetpack Compose/start/src/test/java/com/codelabs/state/todo/TodoViewModelTest.kt
+++ b/week 2-2-Using state in Jetpack Compose/start/src/test/java/com/codelabs/state/todo/TodoViewModelTest.kt
@@ -16,6 +16,22 @@
 
 package com.codelabs.state.todo
 
+import com.codelabs.state.util.generateRandomTodoItem
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
 class TodoViewModelTest {
-    // TODO: Write tests
+
+    @Test
+    fun whenRemovingItem_updatesList() {
+        val viewModel = TodoViewModel()
+        val item1 = generateRandomTodoItem()
+        val item2 = generateRandomTodoItem()
+        viewModel.addItem(item1)
+        viewModel.addItem(item2)
+
+        viewModel.removeItem(item1)
+
+        assertThat(viewModel.todoItems).isEqualTo(listOf(item2))
+    }
 }


### PR DESCRIPTION
layout: parent's x, y and size
measure only once

just like view, measure (requestLayout) -> layout -> draw (invalidate)

modifier order matters


layout state

onedirectional : aftertext changed -> directly update textview
unidirectional : aftertext changed (event) -> update viewmodel (update state) -> UI observes livedata(observable state holder) from viewModel (display state)
// 나는 이게 매우 비효율적이라고 생각했다. 그런데 이게 좋은 것이라고 한다.

activity <-state- viewmodel
viewmodel -event-> activity

stateless composable <-> stateful composables

state  hoisting can make stateless composable

remember gives composable function to have memory
and if it is mutable state then makes it to be recomposed

idempotent  멱등 연산을 여러 번 적용하더라도 결과가 달라지지 않는 성질

mutableState == mutable livedata -> observable 이기 때문에 자기가 업데이트되면 알려줘서 composable이 recompose 되도록함

composable doesn't have visibility cause, it dynamically change

MutableState을 remember 없이도 써지네??
viewmodel에 넣었기 때문에