### PR TITLE
Week3-3: Fix gradle task failed with AndroidTest

### DIFF
--- a/week 3-3-Jetpack Compose Navigation/app/build.gradle
+++ b/week 3-3-Jetpack Compose Navigation/app/build.gradle
@@ -106,6 +106,7 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:2.4.0-beta02"
 
     // Testing dependencies
+    androidTestImplementation 'androidx.test:core:1.4.1-alpha03'
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:$rootProject.espressoVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$rootProject.espressoVersion"

--- a/week 3-3-Jetpack Compose Navigation/app/src/main/AndroidManifest.xml
+++ b/week 3-3-Jetpack Compose Navigation/app/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-
         android:theme="@style/Theme.Rally">
         <activity
             android:name=".RallyActivity"


### PR DESCRIPTION
Problem:

> Task :app:processDebugAndroidTestManifest FAILED
/Users/wan/Study/ComposeFest2021/week 3-3-Jetpack Compose Navigation/app/build/intermediates/tmp/manifest/androidTest/debug/tempFile1ProcessTestManifest11754851143074730775.xml Error:
android:exported needs to be explicitly specified for . Apps targeting Android 12 and higher are required to specify an explicit value for android:exported when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
/Users/wan/Study/ComposeFest2021/week 3-3-Jetpack Compose Navigation/app/build/intermediates/tmp/manifest/androidTest/debug/tempFile1ProcessTestManifest11754851143074730775.xml Error:
android:exported needs to be explicitly specified for . Apps targeting Android 12 and higher are required to specify an explicit value for android:exported when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
/Users/wan/Study/ComposeFest2021/week 3-3-Jetpack Compose Navigation/app/build/intermediates/tmp/manifest/androidTest/debug/tempFile1ProcessTestManifest11754851143074730775.xml Error:
android:exported needs to be explicitly specified for . Apps targeting Android 12 and higher are required to specify an explicit value for android:exported when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.

Solution: https://stackoverflow.com/questions/67654506/manifest-merger-failed-targeting-android-12